### PR TITLE
Add border back on the add/remove buttons to select gear and contacts…

### DIFF
--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -171,7 +171,7 @@ export class Trip extends Component {
           onPress={() => this.toggleContacts(contact.id)}
         >
           <View style={styles.modalToggleContactsContainer}>
-            <Text style={styles.modalToggleBtn}>
+            <Text style={styles.modalToggleBtnText}>
               {!this.state.contacts.includes(contact.id) ? "ADD" : "REMOVE"}
             </Text>
             <Text style={styles.modalOptionsText}
@@ -206,7 +206,7 @@ export class Trip extends Component {
             style={styles.modalToggleGearContainer}
             >
             <Text 
-              style={styles.modalToggleBtn}>
+              style={styles.modalToggleBtnText}>
               {!this.state.gear.includes(gearItem.id) ? "ADD" : "REMOVE"}
             </Text>
             <Text

--- a/components/Trip/styles.js
+++ b/components/Trip/styles.js
@@ -66,6 +66,13 @@ const styles = {
   modalToggleButton: {
     marginVertical: 1
   },
+  modalToggleBtnText: {
+    borderWidth: 1,
+    borderColor: "#001028",
+    height: 30,
+    marginRight: 7,
+    paddingHorizontal: 6
+  },
   modalToggleText: {
     backgroundColor: "#EFB095",
     borderColor: "#001028",


### PR DESCRIPTION
… in the Modal

#### What does this PR do?

Adds the border back to the add/remove buttons in the Modals with multiple selection capabilities.

#### Where should the reviewer start?

Trip styles.js

#### How should this be manually tested?

Check in the simulator. Snapshots are still passing. 

#### Any background context you want to provide?

Although I definitely want to add an images for this task, this will have to do for now.

#### What are the relevant tickets?

https://github.com/Search-and-Rescue/SearchAndRescue-FE/issues/143

#### Screenshots (if appropriate)

![Simulator Screen Shot - iPhone 11 - 2019-10-30 at 21 26 58](https://user-images.githubusercontent.com/44121288/67916783-74674a00-fb5c-11e9-90d3-5a6625658319.png)

#### Questions:

Not at this time.